### PR TITLE
Adding tracker to messages

### DIFF
--- a/pywa/api.py
+++ b/pywa/api.py
@@ -168,6 +168,7 @@ class WhatsAppCloudApi:
         text: str,
         preview_url: bool = False,
         reply_to_message_id: str | None = None,
+        tracker: str | None = None,
     ) -> dict[str, dict | list]:
         """
         Send a text message to a WhatsApp user.
@@ -185,6 +186,7 @@ class WhatsAppCloudApi:
             text: The text to send.
             preview_url: Whether to show a preview of the URL in the message.
             reply_to_message_id: The ID of the message to reply to.
+            tracker: The data that you can track by MessageStatus.
 
         Returns:
             The sent message.
@@ -197,6 +199,9 @@ class WhatsAppCloudApi:
         }
         if reply_to_message_id:
             data["context"] = {"message_id": reply_to_message_id}
+
+        if tracker:
+            data["biz_opaque_callback_data"] = tracker
 
         return self._make_request(
             method="POST",
@@ -312,6 +317,7 @@ class WhatsAppCloudApi:
         is_url: bool,
         caption: str | None = None,
         filename: str | None = None,
+        tracker: str | None = None,
     ) -> dict[str, dict | list]:
         """
         Send a media file to a WhatsApp user.
@@ -331,6 +337,7 @@ class WhatsAppCloudApi:
             media_type: The type of the media file (e.g. 'image', 'video', 'document').
             caption: The caption to send with the media file (only for images, videos and documents).
             filename: The filename to send with the media file (only for documents).
+            tracker: The data that you can track by MessageStatus.
 
         Returns:
             The sent message.
@@ -344,6 +351,7 @@ class WhatsAppCloudApi:
                 **({"caption": caption} if caption else {}),
                 **({"filename": filename} if filename else {}),
             },
+            **({"biz_opaque_callback_data": tracker} if tracker else {}),
         }
         return self._make_request(
             method="POST",
@@ -394,6 +402,7 @@ class WhatsAppCloudApi:
         longitude: float,
         name: str | None = None,
         address: str | None = None,
+        tracker: str | None = None,
     ) -> dict[str, dict | list]:
         """
         Send a location to a WhatsApp user.
@@ -412,6 +421,7 @@ class WhatsAppCloudApi:
             longitude: The longitude of the location.
             name: The name of the location.
             address: The address of the location.
+            tracker: The data that you can track by MessageStatus.
 
         Returns:
             The sent message.
@@ -426,6 +436,7 @@ class WhatsAppCloudApi:
                 "name": name,
                 "address": address,
             },
+            **({"biz_opaque_callback_data": tracker} if tracker else {}),
         }
 
         return self._make_request(
@@ -479,6 +490,7 @@ class WhatsAppCloudApi:
         body: str | None = None,
         footer: str | None = None,
         reply_to_message_id: str | None = None,
+        tracker: str | None = None,
     ) -> dict[str, dict | list]:
         """
         Send an interactive message to a WhatsApp user.
@@ -499,6 +511,7 @@ class WhatsAppCloudApi:
             body: The body of the message.
             footer: The footer of the message.
             reply_to_message_id: The ID of the message to reply to.
+            tracker: The data that you can track by MessageStatus.
 
         Returns:
             The sent message.
@@ -522,6 +535,7 @@ class WhatsAppCloudApi:
                     if reply_to_message_id
                     else {}
                 ),
+                **({"biz_opaque_callback_data": tracker} if tracker else {}),
             },
         )
 
@@ -557,6 +571,7 @@ class WhatsAppCloudApi:
         to: str,
         contacts: tuple[dict[str, Any], ...],
         reply_to_message_id: str | None = None,
+        tracker: str | None = None,
     ) -> dict[str, dict | list]:
         """
         Send a list of contacts to a WhatsApp user.
@@ -573,6 +588,7 @@ class WhatsAppCloudApi:
             to: The WhatsApp ID of the recipient.
             contacts: The contacts to send.
             reply_to_message_id: The ID of the message to reply to.
+            tracker: The data that you can track by MessageStatus.
 
         Returns:
             The sent message.
@@ -585,6 +601,8 @@ class WhatsAppCloudApi:
         }
         if reply_to_message_id:
             data["context"] = {"message_id": reply_to_message_id}
+        if tracker:
+            data["biz_opaque_callback_data"] = tracker
         return self._make_request(
             method="POST",
             endpoint=f"/{self.phone_id}/messages",
@@ -748,6 +766,7 @@ class WhatsAppCloudApi:
         to: str,
         template: dict,
         reply_to_message_id: str | None = None,
+        tracker: str | None = None,
     ) -> dict[str, dict | list]:
         """
         Send a template to a WhatsApp user.
@@ -756,6 +775,7 @@ class WhatsAppCloudApi:
             to: The WhatsApp ID of the recipient.
             template: The template to send.
             reply_to_message_id: The ID of the message to reply to.
+            tracker: The data that you can track by MessageStatus.
 
         Returns example::
 
@@ -774,6 +794,8 @@ class WhatsAppCloudApi:
         }
         if reply_to_message_id:
             data["context"] = {"message_id": reply_to_message_id}
+        if tracker:
+            data["biz_opaque_callback_data"] = tracker
         return self._make_request(
             method="POST",
             endpoint=f"/{self.phone_id}/messages",

--- a/pywa/client.py
+++ b/pywa/client.py
@@ -247,6 +247,7 @@ class WhatsApp(Server, HandlerDecorators):
         preview_url: bool = False,
         reply_to_message_id: str | None = None,
         keyboard: None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Send a message to a WhatsApp user.
@@ -357,6 +358,7 @@ class WhatsApp(Server, HandlerDecorators):
             preview_url: Whether to show a preview of the URL in the message (if any).
             reply_to_message_id: The message ID to reply to (optional).
             keyboard: Deprecated and will be removed in a future version, use ``buttons`` instead.
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The message ID of the sent message.
@@ -377,6 +379,7 @@ class WhatsApp(Server, HandlerDecorators):
                 text=text,
                 preview_url=preview_url,
                 reply_to_message_id=reply_to_message_id,
+                tracker=tracker,
             )["messages"][0]["id"]
         type_, kb = _resolve_buttons_param(buttons)
         return self.api.send_interactive_message(
@@ -391,6 +394,7 @@ class WhatsApp(Server, HandlerDecorators):
             else None,
             body=text,
             footer=footer,
+            tracker=tracker,
         )["messages"][0]["id"]
 
     send_text = send_message  # alias
@@ -405,6 +409,7 @@ class WhatsApp(Server, HandlerDecorators):
         buttons: Iterable[Button] | ButtonUrl | FlowButton | None = None,
         reply_to_message_id: str | None = None,
         mime_type: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Send an image to a WhatsApp user.
@@ -432,6 +437,7 @@ class WhatsApp(Server, HandlerDecorators):
             mime_type: The mime type of the image (optional, required when sending an image as bytes or a file object,
              or file path that does not have an extension).
             body: Deprecated and will be removed in a future version, use ``caption`` instead.
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The message ID of the sent image message.
@@ -460,6 +466,7 @@ class WhatsApp(Server, HandlerDecorators):
                 is_url=is_url,
                 media_type="image",
                 caption=caption,
+                tracker=tracker,
             )["messages"][0]["id"]
         if not caption:
             raise ValueError(
@@ -479,6 +486,7 @@ class WhatsApp(Server, HandlerDecorators):
             body=caption,
             footer=footer,
             reply_to_message_id=reply_to_message_id,
+            tracker=tracker,
         )["messages"][0]["id"]
 
     def send_video(
@@ -491,6 +499,7 @@ class WhatsApp(Server, HandlerDecorators):
         buttons: Iterable[Button] | ButtonUrl | FlowButton | None = None,
         reply_to_message_id: str | None = None,
         mime_type: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Send a video to a WhatsApp user.
@@ -519,6 +528,7 @@ class WhatsApp(Server, HandlerDecorators):
             mime_type: The mime type of the video (optional, required when sending a video as bytes or a file object,
              or file path that does not have an extension).
             body: Deprecated and will be removed in a future version, use ``caption`` instead.
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The message ID of the sent video.
@@ -547,6 +557,7 @@ class WhatsApp(Server, HandlerDecorators):
                 is_url=is_url,
                 media_type="video",
                 caption=caption,
+                tracker=tracker,
             )["messages"][0]["id"]
         if not caption:
             raise ValueError(
@@ -566,6 +577,7 @@ class WhatsApp(Server, HandlerDecorators):
             body=caption,
             footer=footer,
             reply_to_message_id=reply_to_message_id,
+            tracker=tracker,
         )["messages"][0]["id"]
 
     def send_document(
@@ -579,6 +591,7 @@ class WhatsApp(Server, HandlerDecorators):
         buttons: Iterable[Button] | ButtonUrl | FlowButton | None = None,
         reply_to_message_id: str | None = None,
         mime_type: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Send a document to a WhatsApp user.
@@ -609,6 +622,7 @@ class WhatsApp(Server, HandlerDecorators):
             mime_type: The mime type of the document (optional, required when sending a document as bytes or a file
              object, or file path that does not have an extension).
             body: Deprecated and will be removed in a future version, use ``caption`` instead.
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The message ID of the sent document.
@@ -638,6 +652,7 @@ class WhatsApp(Server, HandlerDecorators):
                 media_type="document",
                 caption=caption,
                 filename=filename,
+                tracker=tracker,
             )["messages"][0]["id"]
         if not caption:
             raise ValueError(
@@ -658,6 +673,7 @@ class WhatsApp(Server, HandlerDecorators):
             body=caption,
             footer=footer,
             reply_to_message_id=reply_to_message_id,
+            tracker=tracker,
         )["messages"][0]["id"]
 
     def send_audio(
@@ -665,6 +681,7 @@ class WhatsApp(Server, HandlerDecorators):
         to: str | int,
         audio: str | pathlib.Path | bytes | BinaryIO,
         mime_type: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Send an audio file to a WhatsApp user.
@@ -682,6 +699,7 @@ class WhatsApp(Server, HandlerDecorators):
             audio: The audio file to send (either a media ID, URL, file path, bytes, or an open file object).
             mime_type: The mime type of the audio file (optional, required when sending an audio file as bytes or a file
              object, or file path that does not have an extension).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The message ID of the sent audio file.
@@ -698,6 +716,7 @@ class WhatsApp(Server, HandlerDecorators):
             media_id_or_url=audio,
             is_url=is_url,
             media_type="audio",
+            tracker=tracker,
         )["messages"][0]["id"]
 
     def send_sticker(
@@ -705,6 +724,7 @@ class WhatsApp(Server, HandlerDecorators):
         to: str | int,
         sticker: str | pathlib.Path | bytes | BinaryIO,
         mime_type: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Send a sticker to a WhatsApp user.
@@ -724,6 +744,7 @@ class WhatsApp(Server, HandlerDecorators):
             sticker: The sticker to send (either a media ID, URL, file path, bytes, or an open file object).
             mime_type: The mime type of the sticker (optional, required when sending a sticker as bytes or a file
              object, or file path that does not have an extension).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The message ID of the sent message.
@@ -740,6 +761,7 @@ class WhatsApp(Server, HandlerDecorators):
             media_id_or_url=sticker,
             is_url=is_url,
             media_type="sticker",
+            tracker=tracker,
         )["messages"][0]["id"]
 
     def send_reaction(
@@ -818,6 +840,7 @@ class WhatsApp(Server, HandlerDecorators):
         longitude: float,
         name: str | None = None,
         address: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Send a location to a WhatsApp user.
@@ -839,6 +862,7 @@ class WhatsApp(Server, HandlerDecorators):
             longitude: The longitude of the location.
             name: The name of the location (optional).
             address: The address of the location (optional).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The message ID of the sent location.
@@ -849,15 +873,19 @@ class WhatsApp(Server, HandlerDecorators):
             longitude=longitude,
             name=name,
             address=address,
+            tracker=tracker,
         )["messages"][0]["id"]
 
-    def request_location(self, to: str | int, text: str) -> str:
+    def request_location(
+        self, to: str | int, text: str, tracker: str | None = None
+    ) -> str:
         """
         Send a text message with button to request the user's location.
 
         Args:
             to: The phone ID of the WhatsApp user.
             text: The text to send with the button.
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The message ID of the sent message.
@@ -867,6 +895,7 @@ class WhatsApp(Server, HandlerDecorators):
             type_="location_request_message",
             action={"name": "send_location"},
             body=text,
+            tracker=tracker,
         )["messages"][0]["id"]
 
     def send_contact(
@@ -874,6 +903,7 @@ class WhatsApp(Server, HandlerDecorators):
         to: str | int,
         contact: Contact | Iterable[Contact],
         reply_to_message_id: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Send a contact/s to a WhatsApp user.
@@ -896,6 +926,7 @@ class WhatsApp(Server, HandlerDecorators):
             to: The phone ID of the WhatsApp user.
             contact: The contact/s to send.
             reply_to_message_id: The message ID to reply to (optional).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The message ID of the sent message.
@@ -906,6 +937,7 @@ class WhatsApp(Server, HandlerDecorators):
             if isinstance(contact, Iterable)
             else (contact.to_dict(),),
             reply_to_message_id=reply_to_message_id,
+            tracker=tracker,
         )["messages"][0]["id"]
 
     def send_catalog(
@@ -915,6 +947,7 @@ class WhatsApp(Server, HandlerDecorators):
         footer: str | None = None,
         thumbnail_product_sku: str | None = None,
         reply_to_message_id: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Send the business catalog to a WhatsApp user.
@@ -936,6 +969,7 @@ class WhatsApp(Server, HandlerDecorators):
             thumbnail_product_sku: The thumbnail of this item will be used as the message's header image (optional, if
                 not provided, the first item in the catalog will be used).
             reply_to_message_id: The message ID to reply to (optional).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The message ID of the sent message.
@@ -958,6 +992,7 @@ class WhatsApp(Server, HandlerDecorators):
             body=body,
             footer=footer,
             reply_to_message_id=reply_to_message_id,
+            tracker=tracker,
         )["messages"][0]["id"]
 
     def send_product(
@@ -968,6 +1003,7 @@ class WhatsApp(Server, HandlerDecorators):
         body: str | None = None,
         footer: str | None = None,
         reply_to_message_id: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Send a product from a business catalog to a WhatsApp user.
@@ -993,6 +1029,7 @@ class WhatsApp(Server, HandlerDecorators):
             body: Text to appear in the message body (up to 1024 characters).
             footer: Text to appear in the footer of the message (optional, up to 60 characters).
             reply_to_message_id: The message ID to reply to (optional).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The message ID of the sent message.
@@ -1007,6 +1044,7 @@ class WhatsApp(Server, HandlerDecorators):
             body=body,
             footer=footer,
             reply_to_message_id=reply_to_message_id,
+            tracker=tracker,
         )["messages"][0]["id"]
 
     def send_products(
@@ -1018,6 +1056,7 @@ class WhatsApp(Server, HandlerDecorators):
         body: str,
         footer: str | None = None,
         reply_to_message_id: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Send products from a business catalog to a WhatsApp user.
@@ -1055,6 +1094,7 @@ class WhatsApp(Server, HandlerDecorators):
             body: Text to appear in the message body (up to 1024 characters).
             footer: Text to appear in the footer of the message (optional, up to 60 characters).
             reply_to_message_id: The message ID to reply to (optional).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The message ID of the sent message.
@@ -1070,6 +1110,7 @@ class WhatsApp(Server, HandlerDecorators):
             body=body,
             footer=footer,
             reply_to_message_id=reply_to_message_id,
+            tracker=tracker,
         )["messages"][0]["id"]
 
     def mark_message_as_read(
@@ -1483,6 +1524,7 @@ class WhatsApp(Server, HandlerDecorators):
         to: str | int,
         template: Template,
         reply_to_message_id: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Send a template to a WhatsApp user.
@@ -1529,6 +1571,7 @@ class WhatsApp(Server, HandlerDecorators):
             to: The phone ID of the WhatsApp user.
             template: The template to send.
             reply_to_message_id: The message ID to reply to (optional).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The message ID of the sent template.
@@ -1566,6 +1609,7 @@ class WhatsApp(Server, HandlerDecorators):
             to=str(to),
             template=template.to_dict(is_header_url=is_url),
             reply_to_message_id=reply_to_message_id,
+            tracker=tracker,
         )["messages"][0]["id"]
 
     def create_flow(

--- a/pywa/filters.py
+++ b/pywa/filters.py
@@ -909,6 +909,13 @@ class _MessageStatusFilters(_BaseUpdateFilters):
             or s.error.error_code in error_codes
         )
 
+    with_tracker: _MessageStatusFilterT = lambda _, s: s.tracker is not None
+    """
+    Filter for messages that sent with tracker
+
+    >>> filters.message_status.with_tracker
+    """
+
 
 message_status: _MessageStatusFilterT | type[_MessageStatusFilters] = (
     _MessageStatusFilters

--- a/pywa/types/base_update.py
+++ b/pywa/types/base_update.py
@@ -139,6 +139,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
         quote: bool = False,
         preview_url: bool = False,
         keyboard: None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Reply to the message with text.
@@ -215,6 +216,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             quote: Whether to quote the replied message (default: False).
             preview_url: Whether to show a preview of the URL in the message (if any).
             keyboard: Deprecated and will be removed in a future version, use ``buttons`` instead.
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The ID of the sent reply.
@@ -228,6 +230,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             reply_to_message_id=self.message_id_to_reply if quote else None,
             preview_url=preview_url,
             keyboard=keyboard,
+            tracker=tracker,
         )
 
     reply = reply_text  # alias
@@ -241,6 +244,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
         buttons: Iterable[Button] | ButtonUrl | FlowButton | None = None,
         quote: bool = False,
         mime_type: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Reply to the message with an image.
@@ -267,6 +271,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
              or file path that does not have an extension).
             quote: Whether to quote the replied message (default: False).
             body: Deprecated and will be removed in a future version, use ``caption`` instead.
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The ID of the sent reply.
@@ -280,6 +285,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             buttons=buttons,
             reply_to_message_id=self.message_id_to_reply if quote else None,
             mime_type=mime_type,
+            tracker=tracker,
         )
 
     def reply_video(
@@ -291,6 +297,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
         buttons: Iterable[Button] | ButtonUrl | FlowButton | None = None,
         quote: bool = False,
         mime_type: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Reply to the message with a video.
@@ -318,6 +325,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
              or file path that does not have an extension).
             quote: Whether to quote the replied message (default: False).
             body: Deprecated and will be removed in a future version, use ``caption`` instead.
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The ID of the sent reply.
@@ -343,6 +351,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
         buttons: Iterable[Button] | ButtonUrl | FlowButton | None = None,
         quote: bool = False,
         mime_type: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Reply to the message with a document.
@@ -372,6 +381,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
              object, or file path that does not have an extension).
             body: Deprecated and will be removed in a future version, use ``caption`` instead.
             quote: Whether to quote the replied message (default: False).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The ID of the sent reply.
@@ -386,12 +396,14 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             body=body,
             footer=footer,
             mime_type=mime_type,
+            tracker=tracker,
         )
 
     def reply_audio(
         self,
         audio: str | pathlib.Path | bytes | BinaryIO,
         mime_type: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Reply to the message with an audio.
@@ -407,6 +419,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             audio: The audio file to reply with (either a media ID, URL, file path, bytes, or an open file object).
             mime_type: The mime type of the audio (optional, required when sending a audio as bytes or a file object,
              or file path that does not have an extension).
+             tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The ID of the sent message.
@@ -415,12 +428,14 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             to=self.sender,
             audio=audio,
             mime_type=mime_type,
+            tracker=tracker,
         )
 
     def reply_sticker(
         self,
         sticker: str | pathlib.Path | bytes | BinaryIO,
         mime_type: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Reply to the message with a sticker.
@@ -438,6 +453,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             sticker: The sticker to reply with (either a media ID, URL, file path, bytes, or an open file object).
             mime_type: The mime type of the sticker (optional, required when sending a sticker as bytes or a file
              object, or file path that does not have an extension).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The ID of the sent reply.
@@ -446,6 +462,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             to=self.sender,
             sticker=sticker,
             mime_type=mime_type,
+            tracker=tracker,
         )
 
     def reply_location(
@@ -454,6 +471,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
         longitude: float,
         name: str | None = None,
         address: str | None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Reply to the message with a location.
@@ -474,6 +492,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             longitude: The longitude of the location.
             name: The name of the location (optional).
             address: The address of the location (optional).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The ID of the sent reply.
@@ -484,12 +503,14 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             longitude=longitude,
             name=name,
             address=address,
+            tracker=tracker,
         )
 
     def reply_contact(
         self,
         contact: Contact | Iterable[Contact],
         quote: bool = False,
+        tracker: str | None = None,
     ) -> str:
         """
         Reply to the message with a contact/s.
@@ -512,6 +533,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
         Args:
             contact: The contact/s to send.
             quote: Whether to quote the replied message (default: False).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The ID of the sent reply.
@@ -520,6 +542,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             to=self.sender,
             contact=contact,
             reply_to_message_id=self.message_id_to_reply if quote else None,
+            tracker=tracker,
         )
 
     def react(self, emoji: str) -> str:
@@ -565,6 +588,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
         footer: str | None = None,
         thumbnail_product_sku: str | None = None,
         quote: bool = False,
+        tracker: str | None = None,
     ) -> str:
         """
         Reply to the message with a catalog.
@@ -584,6 +608,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             thumbnail_product_sku: The thumbnail of this item will be used as the message's header image (optional, if
                 not provided, the first item in the catalog will be used).
             quote: Whether to quote the replied message (default: False).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The ID of the sent reply.
@@ -594,6 +619,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             footer=footer,
             thumbnail_product_sku=thumbnail_product_sku,
             reply_to_message_id=self.message_id_to_reply if quote else None,
+            tracker=tracker,
         )
 
     def reply_product(
@@ -603,6 +629,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
         body: str | None = None,
         footer: str | None = None,
         quote: bool = False,
+        tracker: str | None = None,
     ) -> str:
         """
         Reply to the message with a product.
@@ -617,6 +644,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             body: Text to appear in the message body (up to 1024 characters).
             footer: Text to appear in the footer of the message (optional, up to 60 characters).
             quote: Whether to quote the replied message (default: False).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The ID of the sent reply.
@@ -628,6 +656,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             body=body,
             footer=footer,
             reply_to_message_id=self.message_id_to_reply if quote else None,
+            tracker=tracker,
         )
 
     def reply_products(
@@ -638,6 +667,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
         body: str,
         footer: str | None = None,
         quote: bool = False,
+        tracker: str | None = None,
     ) -> str:
         """
         Reply to the message with a product.
@@ -674,6 +704,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             body: Text to appear in the message body (up to 1024 characters).
             footer: Text to appear in the footer of the message (optional, up to 60 characters).
             quote: Whether to quote the replied message (default: False).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The ID of the sent reply.
@@ -686,12 +717,14 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             body=body,
             footer=footer,
             reply_to_message_id=self.message_id_to_reply if quote else None,
+            tracker=tracker,
         )
 
     def reply_template(
         self,
         template: Template,
         quote: bool = False,
+        tracker: str | None = None,
     ) -> str:
         """
         Reply to the message with a template.
@@ -736,6 +769,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
         Args:
             template: The template to send.
             quote: Whether to quote the replied message (default: False).
+            tracker: The data to track the message with (optional, up to 512 characters).
 
         Returns:
             The ID of the sent reply.
@@ -747,6 +781,7 @@ class BaseUserUpdate(BaseUpdate, abc.ABC):
             to=self.sender,
             template=template,
             reply_to_message_id=quote if quote else None,
+            tracker=tracker,
         )
 
     def mark_as_read(self) -> bool:

--- a/pywa/types/message.py
+++ b/pywa/types/message.py
@@ -220,6 +220,7 @@ class Message(BaseUserUpdate):
         preview_url: bool = False,
         reply_to_message_id: str = None,
         keyboard: None = None,
+        tracker: str | None = None,
     ) -> str:
         """
         Send the message to another user.
@@ -238,6 +239,7 @@ class Message(BaseUserUpdate):
             reply_to_message_id:  The message ID to reply to (optional).
             preview_url: Whether to show a preview of the URL in the message (if any).
             keyboard: Deprecated and will be removed in a future version, use ``buttons`` instead.
+            tracker: The track data of the message.
 
         Returns:
             The ID of the sent message.
@@ -257,6 +259,7 @@ class Message(BaseUserUpdate):
                     buttons=buttons,
                     reply_to_message_id=reply_to_message_id,
                     keyboard=keyboard,
+                    tracker=tracker,
                 )
             case MessageType.DOCUMENT:
                 return self._client.send_document(
@@ -268,6 +271,7 @@ class Message(BaseUserUpdate):
                     footer=footer,
                     buttons=keyboard or buttons,
                     reply_to_message_id=reply_to_message_id,
+                    tracker=tracker,
                 )
             case MessageType.IMAGE:
                 return self._client.send_image(
@@ -278,6 +282,7 @@ class Message(BaseUserUpdate):
                     footer=footer,
                     buttons=keyboard or buttons,
                     reply_to_message_id=reply_to_message_id,
+                    tracker=tracker,
                 )
             case MessageType.VIDEO:
                 return self._client.send_video(
@@ -288,9 +293,12 @@ class Message(BaseUserUpdate):
                     body=body,
                     footer=footer,
                     reply_to_message_id=reply_to_message_id,
+                    tracker=tracker,
                 )
             case MessageType.STICKER:
-                return self._client.send_sticker(to=to, sticker=self.sticker.id)
+                return self._client.send_sticker(
+                    to=to, sticker=self.sticker.id, tracker=tracker
+                )
             case MessageType.LOCATION:
                 return self._client.send_location(
                     to=to,
@@ -298,14 +306,18 @@ class Message(BaseUserUpdate):
                     longitude=self.location.longitude,
                     name=self.location.name,
                     address=self.location.address,
+                    tracker=tracker,
                 )
             case MessageType.AUDIO:
-                return self._client.send_audio(to=to, audio=self.audio.id)
+                return self._client.send_audio(
+                    to=to, audio=self.audio.id, tracker=tracker
+                )
             case MessageType.CONTACTS:
                 return self._client.send_contact(
                     to=to,
                     contact=self.contacts,
                     reply_to_message_id=reply_to_message_id,
+                    tracker=tracker,
                 )
             case MessageType.REACTION:
                 if reply_to_message_id is None:

--- a/pywa/types/message_status.py
+++ b/pywa/types/message_status.py
@@ -89,6 +89,7 @@ class MessageStatus(BaseUserUpdate):
         status: The status of the message.
         timestamp: The timestamp when the status was updated.
         from_user: The user who the message was sent to.
+        tracker: The tracker that the message was sent with.
         conversation: The conversation the given status notification belongs to (Optional).
         pricing_model: Type of pricing model used by the business. Current supported value is CBP.
         error: The error that occurred (if status is ``failed``).
@@ -99,6 +100,7 @@ class MessageStatus(BaseUserUpdate):
     from_user: User
     timestamp: dt.datetime
     status: MessageStatusType
+    tracker: str | None
     conversation: Conversation | None
     pricing_model: str | None
     error: WhatsAppError | None
@@ -115,6 +117,7 @@ class MessageStatus(BaseUserUpdate):
             status=MessageStatusType(status["status"]),
             timestamp=dt.datetime.fromtimestamp(int(status["timestamp"])),
             from_user=User(wa_id=status["recipient_id"], name=None),
+            tracker=status.get("biz_opaque_callback_data"),
             conversation=Conversation.from_dict(status["conversation"])
             if "conversation" in status
             else None,

--- a/tests/data/updates/18.0/message_status.json
+++ b/tests/data/updates/18.0/message_status.json
@@ -155,5 +155,46 @@
         ]
       }
     ]
+  },
+  "with_tracker": {
+    "object": "whatsapp_business_account",
+    "entry": [
+      {
+        "id": "5467539754836534",
+        "changes": [
+          {
+            "value": {
+              "messaging_product": "whatsapp",
+              "metadata": {
+                "display_phone_number": "972123456789",
+                "phone_number_id": "1122334455667"
+              },
+              "statuses": [
+                {
+                  "id": "wamid.xyzxyz",
+                  "status": "sent",
+                  "timestamp": "1698266945",
+                  "recipient_id": "972987654321",
+                  "biz_opaque_callback_data": "some data",
+                  "conversation": {
+                    "id": "7270432eae37498234f4444b35ffc5",
+                    "expiration_timestamp": "1698339900",
+                    "origin": {
+                      "type": "service"
+                    }
+                  },
+                  "pricing": {
+                    "billable": true,
+                    "pricing_model": "CBP",
+                    "category": "service"
+                  }
+                }
+              ]
+            },
+            "field": "messages"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -224,6 +224,7 @@ FILTERS: dict[
                 fil.message_status.failed_with(131053),
             ),
         ],
+        "with_tracker": [(same, fil.message_status.with_tracker)],
     },
     "template_status": {
         "approved": [

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -67,6 +67,7 @@ TYPES: dict[str, dict[str, list[Callable[[Any], bool]]]] = {
         "delivered": [lambda s: s.status == MessageStatusType.DELIVERED],
         "read": [lambda s: s.status == MessageStatusType.READ],
         "failed": [lambda s: s.error is not None],
+        "with_tracker": [lambda s: s.tracker is not None],
     },
     "template_status": {
         "approved": [lambda s: s.event == TemplateStatus.TemplateEvent.APPROVED],


### PR DESCRIPTION
[WhatsApp Cloud API](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages#message-object
) has the option to add to any message an optional param called biz_opaque_callback_data, this param value is returned with the message status (sent read etc) and can be used to track messages from specific type for stats or graphs etc. 

In PyWa this param name will be called `tracker` to simplify the reason of using this param.

```python
from pywa import WhatsApp

wa = WhatsApp(...)
wa.send_message(to=...., text="Hi from pywa!", tracker="start_msg")
```

```python
from pywa import WhatsApp, types, filters

wa = WhatsApp(...)

@wa.on_message_status(filters.message_status.read, filters.message_status.with_tracker)
def on_message_read_with_tracker(_: WhatsApp, status: types.MessageStatus):
    if status.tracker == "start_msg":
        print("The message has just been read")
```
