### PR TITLE
Clean MIME type before guessing file extension

### DIFF
--- a/pywa/client.py
+++ b/pywa/client.py
@@ -1646,9 +1646,11 @@ class WhatsApp(Server, _HandlerDecorators, _Listeners):
         if path is None:
             path = os.getcwd()
         if filename is None:
-            filename = hashlib.sha256(url.encode()).hexdigest() + (
-                mimetypes.guess_extension(mimetype) or ".bin"
+            clean_mimetype = mimetype.split(";")[0].strip() if mimetype else None
+            extension = (
+                mimetypes.guess_extension(clean_mimetype) if clean_mimetype else None
             )
+            filename = hashlib.sha256(url.encode()).hexdigest() + (extension or ".bin")
         path = os.path.join(path, filename)
         with open(path, "wb") as f:
             f.write(content)

--- a/pywa/types/media.py
+++ b/pywa/types/media.py
@@ -48,7 +48,8 @@ class BaseMedia(abc.ABC, utils.FromDict):
     @property
     def extension(self) -> str | None:
         """Gets the extension of the media (with dot.)"""
-        return mimetypes.guess_extension(self.mime_type)
+        clean_mimetype = self.mime_type.split(";")[0].strip()
+        return mimetypes.guess_extension(clean_mimetype)
 
     def download(
         self,

--- a/pywa_async/client.py
+++ b/pywa_async/client.py
@@ -1411,9 +1411,11 @@ class WhatsApp(Server, _AsyncListeners, _WhatsApp):
         if path is None:
             path = os.getcwd()
         if filename is None:
-            filename = hashlib.sha256(url.encode()).hexdigest() + (
-                mimetypes.guess_extension(mimetype) or ".bin"
+            clean_mimetype = mimetype.split(";")[0].strip() if mimetype else None
+            extension = (
+                mimetypes.guess_extension(clean_mimetype) if clean_mimetype else None
             )
+            filename = hashlib.sha256(url.encode()).hexdigest() + (extension or ".bin")
         path = os.path.join(path, filename)
         with open(path, "wb") as f:
             f.write(content)


### PR DESCRIPTION
This PR ensures that MIME types are properly cleaned (removing parameters such as codecs) before being passed to `mimetypes.guess_extension()`. This prevents issues where file extensions could not be determined due to extra parameters in the MIME type string, resulting in more robust and reliable media file handling.