### PR TITLE
Add Type Hint to Carousel class to satisfy Type Checking

### DIFF
--- a/pywa/types/templates.py
+++ b/pywa/types/templates.py
@@ -3445,7 +3445,9 @@ class Carousel(TemplateBaseComponent):
             for card in self.cards:
                 card.clear_media_cache()
 
-    def params(self: Carousel | None = None, *, cards: list[CarouselCard._Params]) -> Carousel._Params:
+    def params(
+        self: Carousel | None = None, *, cards: list[CarouselCard._Params]
+    ) -> Carousel._Params:
         """
         Fill the parameters for the carousel component.
 

--- a/pywa/types/templates.py
+++ b/pywa/types/templates.py
@@ -3445,7 +3445,7 @@ class Carousel(TemplateBaseComponent):
             for card in self.cards:
                 card.clear_media_cache()
 
-    def params(self=None, *, cards: list[CarouselCard._Params]) -> Carousel._Params:
+    def params(self: Carousel | None = None, *, cards: list[CarouselCard._Params]) -> Carousel._Params:
         """
         Fill the parameters for the carousel component.
 


### PR DESCRIPTION
This PR addresses https://github.com/david-lev/pywa/issues/190, where even the Pylance type checker on the `basic` setting does not accept a call to `pywa.types.templates.Carousel.params` without an instance of `Carousel`, because then type checkers detect `Argument of type "None" cannot be assigned to parameter "self" of type "Carousel" in function "params"`, even though the default for the function is already `self=None`. 

At runtime, there is no issue. This is merely a type checking issue. This was addressed by adding a simple type hint to the function definition.