### PR TITLE
Refactor media upload for asynchronous handling with PendingMedia

### DIFF
--- a/pywa/types/flows.py
+++ b/pywa/types/flows.py
@@ -33,7 +33,6 @@ from .. import _helpers as helpers
 from .. import utils
 from .base_update import BaseUserUpdate, RawUpdate  # noqa
 from .media import ArrivedMedia
-from ..errors import PywaDeprecationWarning
 from .others import (
     FacebookApplication,
     MessageType,

--- a/pywa/types/flows.py
+++ b/pywa/types/flows.py
@@ -31,6 +31,7 @@ import httpx
 
 from .. import _helpers as helpers
 from .. import utils
+from ..errors import PywaDeprecationWarning
 from .base_update import BaseUserUpdate, RawUpdate  # noqa
 from .media import ArrivedMedia
 from .others import (
@@ -635,7 +636,7 @@ class FlowJSONUpdateResult(SuccessResult):
     def __iter__(self):
         warnings.warn(
             "WhatsApp.update_flow_json() is no longer return (success, validation_errors) tuple, but FlowJSONUpdateResult object.",
-            PyWaDeprecationWarning,
+            PywaDeprecationWarning,
             stacklevel=2,
         )
         return iter((self.success, self.validation_errors))

--- a/pywa/types/others.py
+++ b/pywa/types/others.py
@@ -5,7 +5,7 @@ import time
 import warnings
 from collections.abc import Sequence
 
-from ..errors import WhatsAppError, PywaDeprecationWarning
+from ..errors import PywaDeprecationWarning, WhatsAppError
 from .user import BaseUser
 
 """Types for other objects."""

--- a/pywa_async/client.py
+++ b/pywa_async/client.py
@@ -20,6 +20,7 @@ from typing import (
     Iterable,
     Iterator,
     Literal,
+    Awaitable,
 )
 
 import httpx
@@ -134,7 +135,7 @@ from .types.groups import (
     GroupOperation,
     GroupParticipant,
 )
-from .types.media import Media
+from .types.media import Media, PendingMedia
 from .types.others import (
     BlockedUser,
     CreatedBusinessPhoneNumber,
@@ -1656,7 +1657,7 @@ class WhatsApp(Server, _AsyncListeners, _WhatsApp):
         )
 
     # noinspection PyMethodOverriding
-    async def upload_media(
+    def upload_media(
         self,
         media: str
         | int
@@ -1674,7 +1675,7 @@ class WhatsApp(Server, _AsyncListeners, _WhatsApp):
         media_type: Literal["image", "video", "audio", "document", "sticker"]
         | None = None,
         phone_id: str | int | None = None,
-    ) -> Media:
+    ) -> Awaitable[Media]:
         """
         Upload media to WhatsApp servers.
 
@@ -1712,23 +1713,25 @@ class WhatsApp(Server, _AsyncListeners, _WhatsApp):
         Returns:
             The uploaded media.
         """
-        return await helpers.internal_upload_media(
-            media=media,
-            media_source=helpers.detect_media_source(media),
-            media_type=media_type,
-            mime_type=mime_type,
-            filename=filename,
-            ttl_minutes=int(ttl.total_seconds() // 60)
-            if isinstance(ttl, datetime.timedelta)
-            else ttl,
-            wa=self,
-            phone_id=helpers.resolve_arg(
+        return PendingMedia(
+            helpers.internal_upload_media(
+                media=media,
+                media_source=helpers.detect_media_source(media),
+                media_type=media_type,
+                mime_type=mime_type,
+                filename=filename,
+                ttl_minutes=int(ttl.total_seconds() // 60)
+                if isinstance(ttl, datetime.timedelta)
+                else ttl,
                 wa=self,
-                value=phone_id,
-                method_arg="phone_id",
-                client_arg="phone_id",
-            ),
-            dl_session=dl_session,
+                phone_id=helpers.resolve_arg(
+                    wa=self,
+                    value=phone_id,
+                    method_arg="phone_id",
+                    client_arg="phone_id",
+                ),
+                dl_session=dl_session,
+            )
         )
 
     async def get_media_url(self, media_id: str | int) -> MediaURL:

--- a/pywa_async/client.py
+++ b/pywa_async/client.py
@@ -20,7 +20,6 @@ from typing import (
     Iterable,
     Iterator,
     Literal,
-    Awaitable,
 )
 
 import httpx
@@ -1659,14 +1658,16 @@ class WhatsApp(Server, _AsyncListeners, _WhatsApp):
     # noinspection PyMethodOverriding
     def upload_media(
         self,
-        media: str
-        | int
-        | Media
-        | pathlib.Path
-        | bytes
-        | BinaryIO
-        | Iterator[bytes]
-        | AsyncIterator[bytes],
+        media: (
+            str
+            | int
+            | Media
+            | pathlib.Path
+            | bytes
+            | BinaryIO
+            | Iterator[bytes]
+            | AsyncIterator[bytes]
+        ),
         mime_type: str | None = None,
         filename: str | None = None,
         dl_session: httpx.AsyncClient | None = None,

--- a/pywa_async/client.py
+++ b/pywa_async/client.py
@@ -1675,7 +1675,7 @@ class WhatsApp(Server, _AsyncListeners, _WhatsApp):
         media_type: Literal["image", "video", "audio", "document", "sticker"]
         | None = None,
         phone_id: str | int | None = None,
-    ) -> Awaitable[Media]:
+    ) -> PendingMedia:
         """
         Upload media to WhatsApp servers.
 

--- a/pywa_async/server.py
+++ b/pywa_async/server.py
@@ -4,11 +4,11 @@ import logging
 import warnings
 from typing import TYPE_CHECKING
 
-from .errors import PywaDeprecationWarning
 from pywa.types.base_update import BaseUpdate
 
 from . import _helpers as helpers
 from . import errors, handlers, utils
+from .errors import PywaDeprecationWarning
 from .handlers import (
     EncryptedFlowRequestType,
     Handler,

--- a/pywa_async/types/media.py
+++ b/pywa_async/types/media.py
@@ -16,7 +16,7 @@ __all__ = [
 import dataclasses
 import datetime
 import pathlib
-from typing import TYPE_CHECKING, AsyncGenerator
+from typing import TYPE_CHECKING, AsyncGenerator, Awaitable, Any, Generator, Coroutine
 
 from pywa.types.media import *  # noqa MUST BE IMPORTED FIRST
 from pywa.types.media import (
@@ -220,6 +220,37 @@ class Media(_MediaActionsAsync, _Media):
 
     async def __aexit__(self, exc_type, exc_value, traceback):
         await self.delete()
+
+
+class PendingMedia(Awaitable[Media]):
+    """
+    A wrapper for media upload operations that supports both direct awaiting
+    and asynchronous context management.
+
+    This class defers the execution of the upload until the object is either
+    awaited or entered via an ``async with`` block. It caches the result
+    to ensure that the upload occurs only once.
+    """
+
+    def __init__(self, coro: Coroutine[Any, Any, Media]):
+        self._coro = coro
+        self._media: Media | None = None
+
+    async def _handle_caching(self) -> Media:
+        if self._media is None:
+            self._media = await self._coro
+        return self._media
+
+    def __await__(self) -> Generator[Any, None, Media]:
+        return self._handle_caching().__await__()
+
+    async def __aenter__(self) -> "Media":
+        media = await self
+        return await media.__aenter__()
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        if self._media:
+            await self._media.__aexit__(exc_type, exc_value, traceback)
 
 
 @dataclasses.dataclass(frozen=True, slots=True, kw_only=True)

--- a/pywa_async/types/media.py
+++ b/pywa_async/types/media.py
@@ -16,7 +16,7 @@ __all__ = [
 import dataclasses
 import datetime
 import pathlib
-from typing import TYPE_CHECKING, AsyncGenerator, Awaitable, Any, Generator, Coroutine
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Coroutine, Generator
 
 from pywa.types.media import *  # noqa MUST BE IMPORTED FIRST
 from pywa.types.media import (

--- a/pywa_async/types/message.py
+++ b/pywa_async/types/message.py
@@ -12,7 +12,6 @@ __all__ = [
 ]
 
 import dataclasses
-import datetime
 import pathlib
 from typing import TYPE_CHECKING, AsyncGenerator, ClassVar, Iterable
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -313,6 +313,7 @@ def test_all_methods_are_overwritten_in_async(overrides):
     skip_methods = [
         m.__name__
         for m in {
+            WhatsAppSync.upload_media,
             WhatsAppSync.stream_media,
             WhatsAppSync.add_handlers,
             WhatsAppSync.remove_handlers,
@@ -480,6 +481,7 @@ def test_same_signature(overrides):
 
 def test_same_return_annotation(overrides):
     skip_methods = [
+        WhatsAppSync.upload_media.__name__,
         WhatsAppSync.stream_media.__name__,
         GraphAPISync.stream_media_bytes.__name__,
         MediaSync.stream.__name__,


### PR DESCRIPTION
```py
# old code
async with await wa.upload_media("img.jpg") as media:
	await msg.reply_image(media)

# new code
async with wa.upload_media("img.jpg") as media:  # without await 'twice'
        await msg.reply_image(media)
```