### PR TITLE
[callback] treat missing message context as no reply_to_message in template quick-reply

### DIFF
--- a/pywa/types/callback.py
+++ b/pywa/types/callback.py
@@ -258,7 +258,7 @@ class CallbackButton(BaseUserUpdate, Generic[_CallbackDataT]):
         type: The message type (:class:`MessageType.INTERACTIVE` for :class:`~pywa.types.callback.Button` presses or :class:`MessageType.BUTTON` for :class:`~pywa.types.templates.QuickReplyButton` clicks).
         from_user: The user who sent the message.
         timestamp: The timestamp when the message was sent (in UTC).
-        reply_to_message: The message to which this callback button is a reply to (``None`` when WhatsApp omits the ``context`` field).
+        reply_to_message: The message to which this callback button is a reply to. ``None`` when a template :class:`~pywa.types.templates.QuickReplyButton` is clicked (WhatsApp omits the ``context`` field for template ``button`` messages).
         data: The data of the button (the ``callback_data`` parameter you provided in :class:`~pywa.types.callback.Button` or :class:`~pywa.types.templates.QuickReplyButton`).
         title: The title of the button.
         shared_data: Shared data between handlers.
@@ -357,14 +357,14 @@ class CallbackSelection(BaseUserUpdate, Generic[_CallbackDataT]):
         type: The message type (always :class:`MessageType.INTERACTIVE`).
         from_user: The user who sent the message.
         timestamp: The timestamp when the message was sent (in UTC).
-        reply_to_message: The message to which this callback selection is a reply to (``None`` when WhatsApp omits the ``context`` field).
+        reply_to_message: The message to which this callback selection is a reply to.
         data: The data of the selection (the ``callback_data`` parameter you provided in :class:`~pywa.types.callback.SectionRow`).
         title: The title of the selection.
         description: The description of the selection (optional).
     """
 
     type: MessageType
-    reply_to_message: ReplyToMessage | None
+    reply_to_message: ReplyToMessage
     data: _CallbackDataT
     title: str
     description: str | None
@@ -377,7 +377,6 @@ class CallbackSelection(BaseUserUpdate, Generic[_CallbackDataT]):
         msg = (value := (entry := update["entry"][0])["changes"][0]["value"])[
             "messages"
         ][0]
-        context = msg.get("context", {})
         return cls(
             _client=client,
             raw=update,
@@ -387,9 +386,7 @@ class CallbackSelection(BaseUserUpdate, Generic[_CallbackDataT]):
             type=MessageType(msg["type"]),
             from_user=client._usr_cls.from_contact(value["contacts"][0], client=client),
             timestamp=helpers.timestamp_to_datetime(msg["timestamp"]),
-            reply_to_message=ReplyToMessage.from_dict(context)
-            if context.get("id")
-            else None,
+            reply_to_message=ReplyToMessage.from_dict(msg["context"]),
             data=msg["interactive"]["list_reply"]["id"],
             title=msg["interactive"]["list_reply"]["title"],
             description=msg["interactive"]["list_reply"].get("description"),

--- a/pywa/types/callback.py
+++ b/pywa/types/callback.py
@@ -258,14 +258,14 @@ class CallbackButton(BaseUserUpdate, Generic[_CallbackDataT]):
         type: The message type (:class:`MessageType.INTERACTIVE` for :class:`~pywa.types.callback.Button` presses or :class:`MessageType.BUTTON` for :class:`~pywa.types.templates.QuickReplyButton` clicks).
         from_user: The user who sent the message.
         timestamp: The timestamp when the message was sent (in UTC).
-        reply_to_message: The message to which this callback button is a reply to.
+        reply_to_message: The message to which this callback button is a reply to (``None`` when WhatsApp omits the ``context`` field).
         data: The data of the button (the ``callback_data`` parameter you provided in :class:`~pywa.types.callback.Button` or :class:`~pywa.types.templates.QuickReplyButton`).
         title: The title of the button.
         shared_data: Shared data between handlers.
     """
 
     type: MessageType
-    reply_to_message: ReplyToMessage
+    reply_to_message: ReplyToMessage | None
     data: _CallbackDataT
     title: str
 
@@ -286,6 +286,7 @@ class CallbackButton(BaseUserUpdate, Generic[_CallbackDataT]):
                 data = msg["button"]["payload"]
             case _:
                 raise ValueError(f"Invalid message type {msg_type}")
+        context = msg.get("context", {})
         return cls(
             _client=client,
             raw=update,
@@ -295,7 +296,9 @@ class CallbackButton(BaseUserUpdate, Generic[_CallbackDataT]):
             type=MessageType(msg_type),
             from_user=client._usr_cls.from_contact(value["contacts"][0], client=client),
             timestamp=helpers.timestamp_to_datetime(msg["timestamp"]),
-            reply_to_message=ReplyToMessage.from_dict(msg["context"]),
+            reply_to_message=ReplyToMessage.from_dict(context)
+            if context.get("id")
+            else None,
             data=data,
             title=title,
         )
@@ -354,14 +357,14 @@ class CallbackSelection(BaseUserUpdate, Generic[_CallbackDataT]):
         type: The message type (always :class:`MessageType.INTERACTIVE`).
         from_user: The user who sent the message.
         timestamp: The timestamp when the message was sent (in UTC).
-        reply_to_message: The message to which this callback selection is a reply to.
+        reply_to_message: The message to which this callback selection is a reply to (``None`` when WhatsApp omits the ``context`` field).
         data: The data of the selection (the ``callback_data`` parameter you provided in :class:`~pywa.types.callback.SectionRow`).
         title: The title of the selection.
         description: The description of the selection (optional).
     """
 
     type: MessageType
-    reply_to_message: ReplyToMessage
+    reply_to_message: ReplyToMessage | None
     data: _CallbackDataT
     title: str
     description: str | None
@@ -374,6 +377,7 @@ class CallbackSelection(BaseUserUpdate, Generic[_CallbackDataT]):
         msg = (value := (entry := update["entry"][0])["changes"][0]["value"])[
             "messages"
         ][0]
+        context = msg.get("context", {})
         return cls(
             _client=client,
             raw=update,
@@ -383,7 +387,9 @@ class CallbackSelection(BaseUserUpdate, Generic[_CallbackDataT]):
             type=MessageType(msg["type"]),
             from_user=client._usr_cls.from_contact(value["contacts"][0], client=client),
             timestamp=helpers.timestamp_to_datetime(msg["timestamp"]),
-            reply_to_message=ReplyToMessage.from_dict(msg["context"]),
+            reply_to_message=ReplyToMessage.from_dict(context)
+            if context.get("id")
+            else None,
             data=msg["interactive"]["list_reply"]["id"],
             title=msg["interactive"]["list_reply"]["title"],
             description=msg["interactive"]["list_reply"].get("description"),

--- a/pywa_async/types/callback.py
+++ b/pywa_async/types/callback.py
@@ -46,7 +46,7 @@ class CallbackButton(BaseUserUpdateAsync, _CallbackButton[_CallbackDataT]):
         type: The message type (:class:`MessageType.INTERACTIVE` for :class:`~pywa.types.callback.Button` presses or :class:`MessageType.BUTTON` for :class:`~pywa.types.templates.QuickReplyButton` clicks).
         from_user: The user who sent the message.
         timestamp: The timestamp when the message was sent (in UTC).
-        reply_to_message: The message to which this callback button is a reply to.
+        reply_to_message: The message to which this callback button is a reply to (``None`` when WhatsApp omits the ``context`` field).
         data: The data of the button (the ``callback_data`` parameter you provided in :class:`~pywa.types.callback.Button` or :class:`~pywa.types.templates.QuickReplyButton`).
         title: The title of the button.
         shared_data: Shared data between handlers.
@@ -95,7 +95,7 @@ class CallbackSelection(BaseUserUpdateAsync, _CallbackSelection[_CallbackDataT])
         type: The message type (always :class:`MessageType.INTERACTIVE`).
         from_user: The user who sent the message.
         timestamp: The timestamp when the message was sent (in UTC).
-        reply_to_message: The message to which this callback selection is a reply to.
+        reply_to_message: The message to which this callback selection is a reply to (``None`` when WhatsApp omits the ``context`` field).
         data: The data of the selection (the ``callback_data`` parameter you provided in :class:`~pywa.types.callback.SectionRow`).
         title: The title of the selection.
         description: The description of the selection (optional).

--- a/pywa_async/types/callback.py
+++ b/pywa_async/types/callback.py
@@ -46,7 +46,7 @@ class CallbackButton(BaseUserUpdateAsync, _CallbackButton[_CallbackDataT]):
         type: The message type (:class:`MessageType.INTERACTIVE` for :class:`~pywa.types.callback.Button` presses or :class:`MessageType.BUTTON` for :class:`~pywa.types.templates.QuickReplyButton` clicks).
         from_user: The user who sent the message.
         timestamp: The timestamp when the message was sent (in UTC).
-        reply_to_message: The message to which this callback button is a reply to (``None`` when WhatsApp omits the ``context`` field).
+        reply_to_message: The message to which this callback button is a reply to. ``None`` when a template :class:`~pywa.types.templates.QuickReplyButton` is clicked (WhatsApp omits the ``context`` field for template ``button`` messages).
         data: The data of the button (the ``callback_data`` parameter you provided in :class:`~pywa.types.callback.Button` or :class:`~pywa.types.templates.QuickReplyButton`).
         title: The title of the button.
         shared_data: Shared data between handlers.
@@ -95,7 +95,7 @@ class CallbackSelection(BaseUserUpdateAsync, _CallbackSelection[_CallbackDataT])
         type: The message type (always :class:`MessageType.INTERACTIVE`).
         from_user: The user who sent the message.
         timestamp: The timestamp when the message was sent (in UTC).
-        reply_to_message: The message to which this callback selection is a reply to (``None`` when WhatsApp omits the ``context`` field).
+        reply_to_message: The message to which this callback selection is a reply to.
         data: The data of the selection (the ``callback_data`` parameter you provided in :class:`~pywa.types.callback.SectionRow`).
         title: The title of the selection.
         description: The description of the selection (optional).

--- a/tests/data/updates/callback_button.json
+++ b/tests/data/updates/callback_button.json
@@ -93,5 +93,48 @@
         ]
       }
     ]
+  },
+  "quick_reply_without_context": {
+    "object": "whatsapp_business_account",
+    "entry": [
+      {
+        "id": "5467539754836534",
+        "changes": [
+          {
+            "value": {
+              "messaging_product": "whatsapp",
+              "metadata": {
+                "display_phone_number": "972123456789",
+                "phone_number_id": "1122334455667"
+              },
+              "contacts": [
+                {
+                  "profile": {
+                    "name": "Test Name"
+                  },
+                  "wa_id": "972987654321",
+                  "user_id": "US.13491208655302741918",
+                  "parent_user_id": "US.ENT.11815799212886844830"
+                }
+              ],
+              "messages": [
+                {
+                  "from": "972987654321",
+                  "from_user_id": "US.13491208655302741918",
+                  "id": "wamid.xsidjx",
+                  "timestamp": "1698269027",
+                  "type": "button",
+                  "button": {
+                    "payload": "callback_data",
+                    "text": "title"
+                  }
+                }
+              ]
+            },
+            "field": "messages"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/tests/data/updates/callback_selection.json
+++ b/tests/data/updates/callback_selection.json
@@ -97,5 +97,50 @@
         ]
       }
     ]
+  },
+  "callback_without_context": {
+    "object": "whatsapp_business_account",
+    "entry": [
+      {
+        "id": "1234567890987654321",
+        "changes": [
+          {
+            "value": {
+              "messaging_product": "whatsapp",
+              "metadata": {
+                "display_phone_number": "972123456789",
+                "phone_number_id": "1122334455667"
+              },
+              "contacts": [
+                {
+                  "profile": {
+                    "name": "Test Name"
+                  },
+                  "wa_id": "972987654321",
+                  "user_id": "US.13491208655302741918",
+                  "parent_user_id": "US.ENT.11815799212886844830"
+                }
+              ],
+              "messages": [
+                {
+                  "from": "972987654321",
+                  "id": "wamid.zyzxyw",
+                  "timestamp": "1698266905",
+                  "type": "interactive",
+                  "interactive": {
+                    "type": "list_reply",
+                    "list_reply": {
+                      "id": "callback_data",
+                      "title": "title"
+                    }
+                  }
+                }
+              ]
+            },
+            "field": "messages"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/tests/data/updates/callback_selection.json
+++ b/tests/data/updates/callback_selection.json
@@ -97,50 +97,5 @@
         ]
       }
     ]
-  },
-  "callback_without_context": {
-    "object": "whatsapp_business_account",
-    "entry": [
-      {
-        "id": "1234567890987654321",
-        "changes": [
-          {
-            "value": {
-              "messaging_product": "whatsapp",
-              "metadata": {
-                "display_phone_number": "972123456789",
-                "phone_number_id": "1122334455667"
-              },
-              "contacts": [
-                {
-                  "profile": {
-                    "name": "Test Name"
-                  },
-                  "wa_id": "972987654321",
-                  "user_id": "US.13491208655302741918",
-                  "parent_user_id": "US.ENT.11815799212886844830"
-                }
-              ],
-              "messages": [
-                {
-                  "from": "972987654321",
-                  "id": "wamid.zyzxyw",
-                  "timestamp": "1698266905",
-                  "type": "interactive",
-                  "interactive": {
-                    "type": "list_reply",
-                    "list_reply": {
-                      "id": "callback_data",
-                      "title": "title"
-                    }
-                  }
-                }
-              ]
-            },
-            "field": "messages"
-          }
-        ]
-      }
-    ]
   }
 }

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -66,12 +66,29 @@ TESTS: dict[str, dict[str, list[Callable[[Any], bool]]]] = {
         "media_with_url": [lambda m: m.media.url is not None],
     },
     "callback_button": {
-        "button": [lambda b: b.type == MessageType.INTERACTIVE],
-        "quick_reply": [lambda b: b.type == MessageType.BUTTON],
+        "button": [
+            lambda b: b.type == MessageType.INTERACTIVE,
+            lambda b: b.reply_to_message is not None,
+        ],
+        "quick_reply": [
+            lambda b: b.type == MessageType.BUTTON,
+            lambda b: b.reply_to_message is not None,
+        ],
+        "quick_reply_without_context": [
+            lambda b: b.type == MessageType.BUTTON,
+            lambda b: b.reply_to_message is None,
+        ],
     },
     "callback_selection": {
-        "callback": [lambda s: s.data is not None],
+        "callback": [
+            lambda s: s.data is not None,
+            lambda s: s.reply_to_message is not None,
+        ],
         "description": [lambda s: s.description is not None],
+        "callback_without_context": [
+            lambda s: s.data is not None,
+            lambda s: s.reply_to_message is None,
+        ],
     },
     "message_status": {
         "sent": [lambda s: s.status == MessageStatusType.SENT],

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -80,15 +80,8 @@ TESTS: dict[str, dict[str, list[Callable[[Any], bool]]]] = {
         ],
     },
     "callback_selection": {
-        "callback": [
-            lambda s: s.data is not None,
-            lambda s: s.reply_to_message is not None,
-        ],
+        "callback": [lambda s: s.data is not None],
         "description": [lambda s: s.description is not None],
-        "callback_without_context": [
-            lambda s: s.data is not None,
-            lambda s: s.reply_to_message is None,
-        ],
     },
     "message_status": {
         "sent": [lambda s: s.status == MessageStatusType.SENT],


### PR DESCRIPTION
## The bug

WhatsApp Cloud API does not always include the `context` field on incoming `type: "button"` messages (template quick-reply presses). We hit this in production (EU WABA, 2026-07-13) with a payload that carried the newer `user_id` / `from_user_id` fields but **no** `context`:

```json
{
  "from": "32400000001",
  "from_user_id": "BE.0000000000000000",
  "id": "wamid.HBg...",
  "timestamp": "1783932397",
  "type": "button",
  "button": {"payload": "...", "text": "..."}
}
```

`CallbackButton.from_update` (and `CallbackSelection.from_update`) index `msg["context"]` unconditionally:

```
File "pywa_async/server.py", line 231, in _call_handlers
    ].from_update(client=self, update=raw_update)
File "pywa/types/callback.py", line 298, in from_update
    reply_to_message=ReplyToMessage.from_dict(msg["context"]),
KeyError: 'context'
```

The server catches this, logs `Failed to construct update`, and still returns 200 — so Meta never redelivers and the user's button press is silently lost (the registered handler never fires).

## The fix

Parse `context` the same way `Message.from_update` already does (`message.py`: `content.get("context", {})` → `ReplyToMessage.from_dict(context) if context.get("id") else None`): treat it as optional and set `reply_to_message=None` when absent. Annotations and docstrings updated to `ReplyToMessage | None` accordingly (matching `Message.reply_to_message`).

## Tests

Added `quick_reply_without_context` / `callback_without_context` update fixtures plus `reply_to_message` assertions in `test_updates.py`. Without the fix, the new fixtures reproduce the production crash immediately (fixture construction in `tests/common.py` raises `KeyError: 'context'`); with it, the full suite passes with no regressions.

Thanks for the great library! 🙏