### PR TITLE
Cache the flow private key instead of parsing it on every request

### DIFF
--- a/pywa/utils.py
+++ b/pywa/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import dataclasses
 import enum
+import functools
 import hashlib
 import hmac
 import importlib
@@ -183,6 +184,27 @@ Returns:
 """
 
 
+@functools.lru_cache(maxsize=8)
+def _load_flow_private_key(private_key: str, password: str | None):
+    """
+    Load and cache a flow's RSA private key.
+
+    Parsing a PEM is expensive — ``cryptography`` validates the RSA key
+    material on load — and it was being done once per flow request, which
+    made it the dominant cost of every data exchange: ~56ms against ~2.8ms
+    for the decryption it enables, with or without a password on the key.
+
+    The key does not change for the life of a process, so it is parsed
+    once per ``(private_key, password)`` pair. The cache is bounded and
+    its keys come from the developer's own configuration, never from a
+    request.
+    """
+    return load_pem_private_key(
+        data=private_key.encode("utf-8"),
+        password=password.encode("utf-8") if password else None,
+    )
+
+
 def default_flow_request_decryptor(
     encrypted_flow_data_b64: str,
     encrypted_aes_key_b64: str,
@@ -218,10 +240,7 @@ def default_flow_request_decryptor(
 
     flow_data = base64.b64decode(encrypted_flow_data_b64)
     iv = base64.b64decode(initial_vector_b64)
-    aes_key = load_pem_private_key(
-        data=private_key.encode("utf-8"),
-        password=password.encode("utf-8") if password else None,
-    ).decrypt(
+    aes_key = _load_flow_private_key(private_key, password).decrypt(
         base64.b64decode(encrypted_aes_key_b64),
         OAEP(
             mgf=MGF1(algorithm=hashes.SHA256()), algorithm=hashes.SHA256(), label=None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -44,6 +44,25 @@ D8SsbEVopM4IbnZi0X5WWyHreEjfBrcP6+/o+3vzi+sq76v17PXlalypi4kuUjAD
 """
 
 
+def test_flow_private_key_is_parsed_once_per_key():
+    """The private key does not change per request, so it is not re-parsed per request."""
+    pywa_utils._load_flow_private_key.cache_clear()
+
+    first = pywa_utils._load_flow_private_key(private_key, "pywa")
+    second = pywa_utils._load_flow_private_key(private_key, "pywa")
+    assert first is second
+    assert pywa_utils._load_flow_private_key.cache_info().hits == 1
+
+    # The password is part of the cache key, so a wrong one is not served
+    # the key a correct one loaded.
+    try:
+        pywa_utils._load_flow_private_key(private_key, "not-the-password")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("a wrong password must not be served the cached key")
+
+
 def test_default_flow_request_decryptor_encryptor():
     payload = {
         "encrypted_flow_data": "sCTmBCqjs0GkkX6n/nyZDuyjpaijuelY3I/8rlr1ZIEymEzCMnDGQdxQ9OGaKw0CEaWSgc/GLhuixa8NTQNYXAyVfTaU9H2FWEabWUb8nbZYRdYy81XHUkDCodl4SvBhhufEag==",


### PR DESCRIPTION
### The problem

`default_flow_request_decryptor` calls `load_pem_private_key` on **every** flow data exchange. Parsing a PEM is expensive — `cryptography` validates the RSA key material on load — and it turns out to dominate the cost of the decryption it exists to enable.

Measured on `master`, 2048-bit key, 30 requests each, averaged:

| key | before | after | |
|---|---|---|---|
| unencrypted | 56.14 ms | 2.81 ms | **20.0×** |
| password-protected | 56.68 ms | 2.79 ms | **20.3×** |

Worth noting it is *not* the password KDF — an unencrypted key costs the same. It affects every flow endpoint.

In practice that is a ceiling of roughly **18 exchanges per second per core**, in synchronous CPU work on the event loop, spent re-answering a question whose answer never changes for the life of the process. We found it while load-testing a flow: every screen tap carried ~56ms that had nothing to do with the screen, and it was by far the largest cost in the journey.

### The change

The key is parsed once per `(private_key, password)` pair, behind a bounded `functools.lru_cache`. Nothing else in the function changes — same OAEP/SHA-256 unwrap, same AES-GCM, same return contract.

That takes the same request to **~2.8 ms**, and the ceiling to nearer **355/s/core**.

### Notes

- **Bounded** (`maxsize=8`), and its keys come from the developer's own configuration — never from a request — so nothing network-facing can grow it.
- **No new exposure:** the key material is already passed into this function on every call and lives in the process's configuration. The cache holds a parsed form of something the caller already has.
- Callers passing a rotated key get a fresh parse, since the PEM string is part of the cache key.
- One test added, in the existing style of `tests/test_server.py`: the key is parsed once, and the password is part of the cache key so a wrong password is not served a key a correct one loaded.

`tests/test_server.py` passes (4/4). The 5 failures and 14 errors elsewhere in the suite are pre-existing on `master` — identical before and after this change.