### PR TITLE
Don't require `user_id` in `User.from_contact`

### DIFF
--- a/pywa/types/user.py
+++ b/pywa/types/user.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 @dataclasses.dataclass(frozen=True, slots=True)
 class BaseUser:
     _client: WhatsApp = dataclasses.field(repr=False, hash=False, compare=False)
-    bsuid: str
+    bsuid: str | None
     wa_id: str | None
     username: str | None
     parent_bsuid: str | None
@@ -92,7 +92,7 @@ class User(BaseUser):
         profile = data.get("profile", {})  # TODO `profile` should not be optional
         return cls(
             _client=client,
-            bsuid=data["user_id"],
+            bsuid=data.get("user_id"),
             wa_id=data.get("wa_id") or None,  # avoid empty string
             name=profile.get("name"),
             username=profile.get("username"),
@@ -101,9 +101,13 @@ class User(BaseUser):
         )
 
     @property
-    def country_code(self) -> str:
-        """The user’s `ISO 3166 alpha-2 <https://www.iso.org/iso-3166-country-codes.html>`_ two-letter country code"""
-        return self.bsuid.split(".")[0]
+    def country_code(self) -> str | None:
+        """
+        The user’s `ISO 3166 alpha-2 <https://www.iso.org/iso-3166-country-codes.html>`_ two-letter country code
+
+        ``None`` when the contact carries no BSUID to derive it from.
+        """
+        return self.bsuid.split(".")[0] if self.bsuid else None
 
     @classmethod
     def from_dict(cls, data: dict, client: WhatsApp) -> User:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -482,3 +482,22 @@ def test_repr(wa_result, fake_item_factory, response_data):
     assert "Result" in r
     assert "has_next=True" in r
     assert "has_previous=True" in r
+
+
+def test_user_from_contact_without_bsuid():
+    """A contact may carry only `wa_id` — e.g. a status for an undeliverable send."""
+    user = types.User.from_contact(data={"wa_id": "1234567890"}, client=wa)
+    assert user.wa_id == "1234567890"
+    assert user.bsuid is None
+    assert user.country_code is None
+    assert user.name is None
+
+
+def test_user_from_contact_with_bsuid():
+    user = types.User.from_contact(
+        data={"wa_id": "1234567890", "user_id": "IL.123", "profile": {"name": "Ori"}},
+        client=wa,
+    )
+    assert user.bsuid == "IL.123"
+    assert user.country_code == "IL"
+    assert user.name == "Ori"


### PR DESCRIPTION
### Problem

`User.from_contact` hard-indexes `data["user_id"]`:

```python
@classmethod
def from_contact(cls, data: dict, client: WhatsApp) -> User:
    profile = data.get("profile", {})  # TODO `profile` should not be optional
    return cls(
        _client=client,
        bsuid=data["user_id"],   # <-- KeyError when absent
        ...
```

A contact can legitimately arrive without it. The case I hit is the contact attached to a status for a message that could not be delivered (`errors[].code == 131026`, "Message undeliverable") — there is no WhatsApp user to identify, so WhatsApp sends only:

```json
{"contacts": [{"wa_id": "..."}]}
```

`MessageStatus.from_update` calls `from_contact` for every status webhook, so this raises `KeyError: 'user_id'`. It's caught and logged in `_call_handlers`, so nothing breaks functionally — but it's an `ERROR` with a traceback for a well-formed payload, which is noisy for anyone routing logs to an error tracker.

### Same shape as #188

#188 fixed `data["profile"]` on the line directly above this one, after status-update contacts turned out to be leaner than message contacts. `user_id` was left required because the payload in that report still had it:

```json
{"wa_id": "972526111549", "user_id": "IL.831795919964525"}
```

An undeliverable-send contact is leaner still — no `profile` *and* no `user_id` — so it trips the one index #188 left behind.

### `bsuid=None` is already reachable

`from_dict` already does `bsuid=data.get("user_id")`, so a `User` with no bsuid can already be constructed today, while `bsuid` is annotated `str` and `country_code` calls `self.bsuid.split(".")`. This PR makes those consistent:

- `from_contact` uses `.get("user_id")`, matching `from_dict`
- `bsuid` is annotated `str | None`
- `country_code` returns `None` instead of raising `AttributeError` when there is no bsuid to split

Happy to trim to just the `.get()` if you'd rather keep the annotation and property as they are.

### Tests

Two cases added to `tests/test_types.py` — a contact with a bsuid and one without, asserting `bsuid`, `country_code`, and `name`.

Full suite before and after this change, same environment: **5 failed / 139 passed / 14 errors** → **5 failed / 141 passed / 14 errors**. The pre-existing failures and collection errors are unrelated to this change and unchanged by it; the delta is the two new tests.
