### PR TITLE
[templates] parse media headers returned without an example

### DIFF
--- a/pywa/_helpers.py
+++ b/pywa/_helpers.py
@@ -727,6 +727,9 @@ def upload_template_media_components(
             for example, comps in itertools.groupby(
                 not_uploaded, key=lambda x: x._example
             )
+            # A component read back from WhatsApp without sample media has nothing to
+            # upload; `to_dict` reports it if such a template is submitted.
+            if example is not None
         ]
         for future in futures.as_completed(tasks):
             future.result()

--- a/pywa/types/templates.py
+++ b/pywa/types/templates.py
@@ -1499,7 +1499,8 @@ class _BaseMediaHeaderComponent(BaseHeaderComponent, abc.ABC):
         | bytes
         | BinaryIO
         | Iterator[bytes]
-        | AsyncIterator[bytes],
+        | AsyncIterator[bytes]
+        | None,
         *,
         mime_type: str | None = None,
     ):
@@ -1507,7 +1508,7 @@ class _BaseMediaHeaderComponent(BaseHeaderComponent, abc.ABC):
         Initializes a media header component for a template.
 
         Args:
-            example: An example of the media to be used in the header (can be a URL, file path, bytes, bytes generator, file-like object, base64 or a :py:class:`~pywa.types.media.Media` instance).
+            example: An example of the media to be used in the header (can be a URL, file path, bytes, bytes generator, file-like object, base64 or a :py:class:`~pywa.types.media.Media` instance). ``None`` only when the component came from a template read back from WhatsApp without sample media; such a component cannot be submitted.
             mime_type: The mime type of the example (optional, required when passing bytes, bytes generator, or path without extension).
         """
         self._example = example
@@ -1526,9 +1527,12 @@ class _BaseMediaHeaderComponent(BaseHeaderComponent, abc.ABC):
         | BinaryIO
         | Iterator[bytes]
         | AsyncIterator[bytes]
+        | None
     ):
         """
         Returns the example media for the header component.
+
+        ``None`` when the template was read back from WhatsApp and no sample media was returned for it.
         """
         return self._example
 
@@ -1552,6 +1556,14 @@ class _BaseMediaHeaderComponent(BaseHeaderComponent, abc.ABC):
 
     @classmethod
     def from_dict(cls, data: dict) -> _BaseMediaHeaderComponent:
+        # WhatsApp does not always return the sample media when a template is read back
+        # (e.g. the sample templates Meta provisions on a new WABA come back as
+        # ``{"type": "HEADER", "format": "IMAGE"}``), so ``example`` can be missing entirely.
+        # Only that exact shape is accepted here: an ``example`` that is present but not the
+        # documented one still raises, so an actual API change is reported rather than
+        # silently parsed into a component with no media.
+        if "example" not in data:
+            return cls(example=None)
         return cls(example=data["example"]["header_handle"][0])
 
     def to_dict(self) -> dict:

--- a/pywa_async/_helpers.py
+++ b/pywa_async/_helpers.py
@@ -381,6 +381,9 @@ async def upload_template_media_components(
             for example, comps in itertools.groupby(
                 not_uploaded, key=lambda x: x._example
             )
+            # A component read back from WhatsApp without sample media has nothing to
+            # upload; `to_dict` reports it if such a template is submitted.
+            if example is not None
         ]
     )
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -9,6 +9,7 @@ from pywa import _helpers as helpers
 from pywa import types
 from pywa.types import flows
 from pywa.types.templates import *
+from pywa.types.templates import _parse_component
 
 
 def _resolve_example_handles(template: Template):
@@ -1121,3 +1122,52 @@ def test_url_button_comp():
             url="https://example.com",
             example="https://example.com?ref=wa&utm=123",
         )
+
+
+def test_media_header_without_example_from_dict(caplog):
+    """WhatsApp omits the sample media when reading back a template it did not receive one for."""
+    for fmt, cls in (
+        ("IMAGE", HeaderImage),
+        ("VIDEO", HeaderVideo),
+        ("DOCUMENT", HeaderDocument),
+    ):
+        comp = _parse_component({"type": "HEADER", "format": fmt})
+        assert isinstance(comp, cls), (
+            f"A {fmt} header without an example should still be parsed as {cls.__name__}"
+        )
+        assert comp.example is None
+    assert not caplog.records, "Parsing should not log anything"
+
+
+def test_media_header_with_example_from_dict():
+    comp = _parse_component(
+        {
+            "type": "HEADER",
+            "format": "IMAGE",
+            "example": {"header_handle": ["1:imagehandle"]},
+        }
+    )
+    assert isinstance(comp, HeaderImage)
+    assert comp.example == "1:imagehandle"
+
+
+def test_media_header_with_unexpected_example_is_reported(caplog):
+    """Only an absent `example` is benign — a present but unexpected one must not be swallowed."""
+    for example in ({}, {"header_handle": []}, {"header_text": ["x"]}):
+        caplog.clear()
+        comp = _parse_component(
+            {"type": "HEADER", "format": "IMAGE", "example": example}
+        )
+        assert comp == {"type": "HEADER", "format": "IMAGE", "example": example}, (
+            "An unparseable component should fall back to its dict representation"
+        )
+        assert caplog.records, f"{example!r} should have been reported, not accepted"
+
+
+def test_media_header_without_example_cannot_be_submitted():
+    """A header read back without sample media has nothing to upload and cannot be sent back."""
+    without_example = HeaderImage(example=None)
+    with pytest.raises(
+        ValueError, match="^HeaderImage media example not uploaded yet.$"
+    ):
+        without_example.to_dict()


### PR DESCRIPTION
### The problem

`_BaseMediaHeaderComponent.from_dict` reads `data["example"]["header_handle"][0]` unconditionally:

```python
@classmethod
def from_dict(cls, data: dict) -> _BaseMediaHeaderComponent:
    return cls(example=data["example"]["header_handle"][0])
```

But WhatsApp does not always return the sample media when a template is read back. The sample templates Meta provisions on a new WABA come back with a bare header:

```json
{"type": "HEADER", "format": "IMAGE"}
```

So `_parse_component` hits `KeyError: 'example'`, logs it at ERROR with a full traceback, and falls back to the raw dict:

```
pywa.types.templates ERROR Failed to parse component: {'type': 'HEADER', 'format': 'IMAGE'}.
Defaulting to raw dictionary representation. Please update pywa or report this issue.
KeyError: 'example'
```

Reproduces on 3.8.0, 3.9.0 and 4.4.0.

### Where I hit it

A WhatsApp Business Account still carrying Meta's "Jasper's Market" onboarding samples. Listing its templates parses three such headers — `jaspers_market_image_cta_v1` plus two media-carousel cards — so each `get_templates()` call emitted three ERROR lines with tracebacks. Nothing downstream broke (the dict fallback is fine), but the log noise tripped our production container-error alert.

Verified against a real WABA that this is specific to templates whose sample media WhatsApp did not receive from the business: a template I created myself with an uploaded `header_handle` gets `example.header_handle` echoed back as a `scontent.whatsapp.net` URL, both while `PENDING` and once `APPROVED`. So approval is not what strips it.

### The change

- `from_dict` treats a missing header handle as what it is — absent on read — and still returns the typed component. `example` may therefore be `None`, which the annotations and docstrings now say.
- A header with no example has nothing to upload, so it is skipped when uploading a template's media (sync and async) rather than reaching `detect_media_source(None)`. Submitting such a template still fails in `to_dict` with the existing `"... media example not uploaded yet."` error.

A component carrying a *malformed* example still goes down the normal path, so a genuine parse regression is still reported.

### Tests

Three cases added to `tests/test_templates.py`: a bare header for each of IMAGE/VIDEO/DOCUMENT parses with no log output, a header with an example still carries its handle, and an example-less header cannot be submitted.

`uv run pytest` — 554 passed. `uv run ruff check .` and `uv run ty check` clean.
